### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "urls": [
+    ["touch.py", "github:robert-hh/XPT2046-touch-pad-driver/touch.py"],
+    ["xpt2046_syn.py", "github:robert-hh/XPT2046-touch-pad-driver/xpt2046_syn.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install the XPT2046 touch screen driver modules.